### PR TITLE
Add Separate Proof mode paper

### DIFF
--- a/src/components/Paper/History/History.js
+++ b/src/components/Paper/History/History.js
@@ -1,0 +1,8 @@
+
+
+export default class History {
+    constructor() {
+        this.data = [];
+        this.index = 0;
+    }
+}

--- a/src/components/Paper/Paper.css
+++ b/src/components/Paper/Paper.css
@@ -16,3 +16,7 @@
 .joint-paper {
     background-color: white;
 }
+
+#main-paper-proof-paper {
+    background-color: #ff92928f;
+}

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -6,6 +6,7 @@ import $ from 'jquery'
 
 import Delete from '../../sounds/delete.wav';
 import Sheet from './Sheet/Sheet.js';
+import History from './History/History.js'
 
 import './Paper.css';   
 
@@ -35,6 +36,8 @@ export default class Paper extends React.Component {
         this.state = {
             show: true
         }
+
+        this.history = [];
     }
 
     componentDidMount() {
@@ -50,6 +53,11 @@ export default class Paper extends React.Component {
         this.paper_element = document.getElementById(this.props.id);
 
         this.setPaperEvents();
+    }
+
+    onGraphUpdate() {
+        const new_graph = this.sheet.exportAsJSON();
+        this.history.push(new_graph);
     }
 
     show() {
@@ -134,6 +142,10 @@ export default class Paper extends React.Component {
             if (this.props.handleClearAction) this.props.handleClearAction();
             this.selected_premise = null;
         });
+
+        this.sheet.graph.on('change', () => {
+            this.onGraphUpdate();
+        })
     }
 
     onClick() {

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -132,6 +132,7 @@ export default class Paper extends React.Component {
 
             if (this.props.action) this.props.action(this.sheet, cell, E.mousePosition);
             if (this.props.handleClearAction) this.props.handleClearAction();
+            this.selected_premise = null;
         });
     }
 
@@ -237,7 +238,6 @@ export default class Paper extends React.Component {
     onMouseUp() {
         //console.log('mouseup', this);
         if (this.getMode() === 'proof') {
-            //console.log('yuh');
             if (!this.selected_premise && this.props.action && this.props.action.name === 'insertDoubleCut') {
                 const mouse_adjusted = this.getRelativeMousePos();
                 this.props.action(this.sheet, null, mouse_adjusted);

--- a/src/components/Paper/Paper.jsx
+++ b/src/components/Paper/Paper.jsx
@@ -53,16 +53,10 @@ export default class Paper extends React.Component {
     }
 
     show() {
-        // this.setState({
-        //     show: true
-        // });
         $(this.paperRoot.current).css('display', 'block');
     }
 
     hide() {
-        // this.setState({
-        //     show: false
-        // })
         $(this.paperRoot.current).css('display', 'none');
     }
 
@@ -143,11 +137,6 @@ export default class Paper extends React.Component {
 
     onClick() {
         console.log('clicked', this);
-        // if (this.getMode() === 'proof' && this.props.action && this.props.action.name === 'inferenceInsertion') {
-        //     const mousePosition = Object.assign({}, E.mousePosition);
-        //     this.props.action(this.sheet, mousePosition);
-        //     this.props.handleClearAction();
-        // }
     }
 
     onKeyDown() {
@@ -159,29 +148,7 @@ export default class Paper extends React.Component {
     }
 
     onKeyUp(event) {
-        //console.log('keyup', this);
         if(this.getMode() === 'proof'){
-            //console.log('here?')
-            //TODO: REPLACE THIS WITH AN INTERFACE TO INSERT ANY SUBGRAPH, currently this only lets you insert a single premise
-            // if(this.props.action && this.props.action.name === 'inferenceInsertion') {
-            //     console.log("HEREEEee");
-            //     if (!this.selected_premise) return;
-            //     if (this.selected_premise.attributes.attrs.level % 2 === 1) return;
-            //     console.log("HERE")
-            //     if (event.keyCode >= 65 && event.keyCode <= 90) {
-            //         let config = {
-            //             //use capital letters by default, can press shift to make lowercase
-            //             attrs:{
-            //                 text: {
-            //                     text:event.shiftKey ? event.key.toLocaleLowerCase() : event.key.toLocaleUpperCase()
-            //                 }
-            //             },
-            //             position: this.getRelativeMousePos()
-            //         }
-            //         this.sheet.addPremise(config);
-            //     }
-            //     this.props.handleClearAction();
-            // }
             return;
         }
         let key = E.key

--- a/src/components/Paper/Sheet/Sheet.js
+++ b/src/components/Paper/Sheet/Sheet.js
@@ -370,8 +370,8 @@ export default class Sheet {
             for (const node of current) {
                 next.push(...node.getEmbeddedCells());
                 //node.move({x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
-                safeMove(node, {x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
-                //node.position(node.attributes.position.x + offset.x, node.attributes.position.y + offset.y);
+                //safeMove(node, {x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
+                node.position(node.attributes.position.x + offset.x, node.attributes.position.y + offset.y);
             }
         }
     }

--- a/src/components/Paper/Sheet/Sheet.js
+++ b/src/components/Paper/Sheet/Sheet.js
@@ -272,6 +272,7 @@ export default class Sheet {
     
     findRoot(node) {
         while (true) {
+            console.log('FIND ROOT NODE', node)
             if (node.get("parent")) {
                 node = node.getParentCell();
             } else {
@@ -344,8 +345,8 @@ export default class Sheet {
             for (const node of current) {
                 next.push(...node.getEmbeddedCells());
                 //node.move({x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
-                //safeMove(node, {x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
-                node.position(node.attributes.position.x + offset.x, node.attributes.position.y + offset.y);
+                safeMove(node, {x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})
+                //node.position(node.attributes.position.x + offset.x, node.attributes.position.y + offset.y);
             }
         }
     

--- a/src/components/Paper/Sheet/Sheet.js
+++ b/src/components/Paper/Sheet/Sheet.js
@@ -41,6 +41,31 @@ export default class Sheet {
         return cut;
     }
 
+    exportAsJSON() {
+        console.log('exporting...');
+        const cells = this.graph.getCells();
+        const exported = cells.map(cell => Object.assign(cell.attributes, { sheet: null }));
+        console.log(exported);
+        const json = JSON.stringify(exported, null, 2);
+        console.log(json);
+        return json;
+    }
+
+    importFromJSON(json) {
+        const parsed = JSON.parse(json);
+        for (let cell of parsed) {
+            if (cell.type === 'dia.Element.Premise') {
+                this.addPremise(cell, true);
+            }
+            else if (cell.type === 'dia.Element.Cut') {
+                this.addCut(cell, true);
+            }
+            else {
+                throw new RangeError(`Cell type must be either dia.Element.Premise or dia.Element.Cut, got ${cell.type}`);
+            }
+        }
+    }
+
     //TODO: some of these functions kind of fit here and also kind of don't. I'm moving them here for now
     // because in the future it would be beneficial to at least have a "entire graph update" be possible, which would be very simple to 
     // do if they are all bundled up.
@@ -349,6 +374,7 @@ export default class Sheet {
                 //node.position(node.attributes.position.x + offset.x, node.attributes.position.y + offset.y);
             }
         }
-    
     }
+
+
 }

--- a/src/components/SideBar/SideBar.jsx
+++ b/src/components/SideBar/SideBar.jsx
@@ -30,7 +30,7 @@ export default class SideBar extends React.Component {
                         text: 'Insertion',
                         onClick: () => {
                             this.props.handleActionChange(inferenceInsertion);
-                            console.log('Performing insertion...');
+                            console.log('Loading insertion into action...');
                         }
                     },
                     {

--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -79,7 +79,6 @@ export default class Workspace extends React.Component {
 
     handleModalInsert = (position) => {
         console.log('inserting...');
-        //console.log(_.cloneDeep(this.modalPaper));
         this.mainPaper.current.copyFrom(this.modalPaper.current);
         this.handleModalExit();
     }

--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -22,6 +22,7 @@ export default class Workspace extends React.Component {
         this.modalPaper = React.createRef();
         this.mainPaper = React.createRef();
         this.proofPaper= React.createRef();
+        this.history = [];
     }
 
     componentDidMount() {

--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -25,7 +25,7 @@ export default class Workspace extends React.Component {
     }
 
     componentDidMount() {
-        //this.proofPaper.current.hide();
+        this.proofPaper.current.hide();
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -34,20 +34,16 @@ export default class Workspace extends React.Component {
          if (prevState.mode !== this.state.mode) {
             //switch to proof mode
             if (this.state.mode === 'proof') {
-                // this.mainPaper.current.hide();
+                this.mainPaper.current.hide();
                 this.proofPaper.current.sheet.graph.clear();
-                this.proofPaper.current.copyFrom(this.mainPaper.current);
-                // this.proofPaper.current.show();
+                this.proofPaper.current.sheet.importFromJSON(this.mainPaper.current.sheet.exportAsJSON());
+                this.proofPaper.current.show();
             }
             //switch to create mode
             else {
-                // this.mainPaper.current.show();
-                // this.proofPaper.current.hide();
+                this.mainPaper.current.show();
+                this.proofPaper.current.hide();
             }
-
-            console.log('GRAPH CELLS', this.mainPaper.current.sheet.graph.getCells())
-            console.log('GRAPH GRAPH', _.cloneDeep(this.mainPaper.current.sheet.graph))
-
         }
     }
 

--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -6,6 +6,7 @@ import Modal from '../Modal/Modal.jsx';
 import _ from 'lodash';
 
 import './Workspace.css'
+import E from '../../EventController';
 
 const LOAD_MODAL = new Event('load-modal');
 
@@ -20,15 +21,40 @@ export default class Workspace extends React.Component {
         this.insertPosition = { x: 0, y: 0 };
         this.modalPaper = React.createRef();
         this.mainPaper = React.createRef();
+        this.proofPaper= React.createRef();
+    }
+
+    componentDidMount() {
+        //this.proofPaper.current.hide();
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+
+        // //if state.mode changed
+         if (prevState.mode !== this.state.mode) {
+            //switch to proof mode
+            if (this.state.mode === 'proof') {
+                // this.mainPaper.current.hide();
+                this.proofPaper.current.sheet.graph.clear();
+                this.proofPaper.current.copyFrom(this.mainPaper.current);
+                // this.proofPaper.current.show();
+            }
+            //switch to create mode
+            else {
+                // this.mainPaper.current.show();
+                // this.proofPaper.current.hide();
+            }
+
+            console.log('GRAPH CELLS', this.mainPaper.current.sheet.graph.getCells())
+            console.log('GRAPH GRAPH', _.cloneDeep(this.mainPaper.current.sheet.graph))
+
+        }
     }
 
     handleStateSwitch() {
-        console.log('Switching state...');
-        console.log(this.state);
         this.setState({
             mode: this.state.mode === 'create' ? 'proof' : 'create'
         });
-        window.mode = this.state.mode === 'create' ? 'proof' : 'create';
     }
 
     handleActionChange(action) {
@@ -93,8 +119,19 @@ export default class Workspace extends React.Component {
                     handleOpenModal={this.handleOpenModal}
                     ref={this.mainPaper}
                 >
-
                 </Paper>
+
+                <Paper 
+                    id={this.props.paper_id + '-proof-paper'} 
+                    mode={this.state.mode} 
+                    action={this.state.action}
+                    handleClearAction={this.handleClearAction.bind(this)}
+                    handleOpenModal={this.handleOpenModal}
+                    ref={this.proofPaper}
+                >
+                </Paper>
+
+
                 <Modal show={this.state.showModal} buttons={buttons}>
                     <Paper 
                         id={this.props.paper_id + '-modal-paper'} 
@@ -104,7 +141,6 @@ export default class Workspace extends React.Component {
                         handleOpenModal={null}
                         wrapperWidth='100%'
                         wrapperHeight='72vh'
-                        isModalPaper={true}
                         ref={this.modalPaper}
                     >
                     </Paper>

--- a/src/components/Workspace/Workspace.jsx
+++ b/src/components/Workspace/Workspace.jsx
@@ -79,7 +79,7 @@ export default class Workspace extends React.Component {
 
     handleModalInsert = (position) => {
         console.log('inserting...');
-        this.mainPaper.current.copyFrom(this.modalPaper.current);
+        this.proofPaper.current.sheet.importFromJSON(this.modalPaper.current.sheet.exportAsJSON());
         this.handleModalExit();
     }
 

--- a/src/shapes/Cut/Cut.js
+++ b/src/shapes/Cut/Cut.js
@@ -88,7 +88,7 @@ export class Cut extends joint.dia.Element {
             },
             // set custom attributes here:
             sheet: options.sheet
-        })
+        });
 
         //have to set this out here since we actually do want a reference to this object, not a copy
         cut.sheet = options.sheet;

--- a/src/shapes/Cut/Cut.js
+++ b/src/shapes/Cut/Cut.js
@@ -87,6 +87,7 @@ export class Cut extends joint.dia.Element {
                 level: 0
             },
             // set custom attributes here:
+            sheet: options.sheet
         })
 
         //have to set this out here since we actually do want a reference to this object, not a copy
@@ -119,10 +120,6 @@ export class Cut extends joint.dia.Element {
             }
         }
         console.log(cut);
-
-        // Play snip sound
-        let snip = new Audio(Snip); 
-        snip.play();
         return cut;
     }
 

--- a/src/shapes/Premise/Premise.js
+++ b/src/shapes/Premise/Premise.js
@@ -69,7 +69,7 @@ export class Premise extends joint.dia.Element {
         options.sheet = sheet;
 
         const premise = new Premise({
-          markup: '<g class="rotatable"><g class="scalable"><rect/></g><text/></g>',
+          markup: '<g class="rotatable"><rect/><text/></g>',
           position: {
               ...options.position
           },

--- a/src/util/proof-util.js
+++ b/src/util/proof-util.js
@@ -26,13 +26,6 @@ export const inferenceErasure = function(sheet, model) {
     if(parent) {
       sheet.handleCollisions(parent);
     }
-    // else {
-    //   children?.forEach(element => {
-    //       if(sheet.graph.getCell(element).__proto__.constructor.name === "Cut") {
-    //         sheet.handleCollisions(sheet.graph.getCell(element))
-    //       }
-    //   });
-    // }  
   }
 }
 

--- a/src/util/proof-util.js
+++ b/src/util/proof-util.js
@@ -6,26 +6,33 @@ import E from '../EventController.js'
 
 export const inferenceInsertion = function(sheet, model, mousePosition) {
   console.log('ARGS', arguments);
-  if(model.__proto__.constructor.name == "Cut" && model.attributes.embeds?.length == 1) return;
+  if(model.__proto__.constructor.name == "Cut" && (model.attributes.level) % 2 === 0) return;
+  console.log('opening modal...')
   const paper = sheet.paper;
   paper.props.handleOpenModal(mousePosition);
 }
 
 export const inferenceErasure = function(sheet, model) {
   console.log(model.attributes.attrs.level)
-  if(model.attributes.attrs.level%2 === 0) {
-    const children = model.attributes.attrs.embeds;
+  if(model.attributes.attrs.level % 2 === 0) {
+    const children = model.getEmbeddedCells({deep: true});
+    const parent = sheet.graph.getCell(model.attributes.parent);
+
     model.destroy();
-    if(model.attributes.parent) {
-      sheet.handleCollisions(sheet.graph.getCell(model.attributes.parent));
+    for (let i = 0; i < children.length; i++){
+      children[i].destroy();
     }
-    else {
-      children?.forEach(element => {
-          if(sheet.graph.getCell(element).__proto__.constructor.name === "Cut") {
-            sheet.handleCollisions(sheet.graph.getCell(element))
-          }
-      });
-    }  
+
+    if(parent) {
+      sheet.handleCollisions(parent);
+    }
+    // else {
+    //   children?.forEach(element => {
+    //       if(sheet.graph.getCell(element).__proto__.constructor.name === "Cut") {
+    //         sheet.handleCollisions(sheet.graph.getCell(element))
+    //       }
+    //   });
+    // }  
   }
 }
 
@@ -34,7 +41,7 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
     let size = {}
     if (!model && mousePosition) {
         position = mousePosition;
-        size = { width: 40, height: 40 }
+        size = { width: 80, height: 80 }
     }
     else if (model){
         position = model.get('position');
@@ -43,12 +50,12 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
     else {
         throw new Error('Bad arguments');
     }
-    const multipliers = [0.5, 0.25];
+    const multipliers = [0.8, 0.25];
     for(let i = 0; i < multipliers.length; i++) { 
         sheet.addCut({
             position:  {
-              x: model.get('position').x - (size.width * multipliers[i]/2),
-              y: model.get('position').y - (size.height * multipliers[i]/2)
+              x: position.x - (size.width * multipliers[i]/2),
+              y: position.y - (size.height * multipliers[i]/2)
             },
             attrs: {
                 rect: {

--- a/src/util/proof-util.js
+++ b/src/util/proof-util.js
@@ -45,8 +45,11 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
     }
     const multipliers = [0.5, 0.25];
     for(let i = 0; i < multipliers.length; i++) { 
-        const cut = sheet.addCut({
-            position: position,
+        sheet.addCut({
+            position:  {
+              x: model.get('position').x - (size.width * multipliers[i]/2),
+              y: model.get('position').y - (size.height * multipliers[i]/2)
+            },
             attrs: {
                 rect: {
                     width: size.width * (1 + multipliers[i]),
@@ -54,11 +57,6 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
                 }
             }
         });
-        cut.set('position', {
-            x: cut.get('position').x - (size.width * multipliers[i]/2),
-            y: cut.get('position').y - (size.height * multipliers[i]/2)
-        });
-        cut.sheet.handleCollisions(cut);
     }  
 }
 


### PR DESCRIPTION
Adds a paper specifically for proof mode.
When switching from create mode to proof mode, all contents from work mode are carried over.
When switching from proof mode back to work mode, the work graph is what it was before.