### PR TITLE
Add Undo/Redo

### DIFF
--- a/src/components/Paper/History/History.js
+++ b/src/components/Paper/History/History.js
@@ -4,5 +4,66 @@ export default class History {
     constructor() {
         this.data = [];
         this.index = 0;
+        this.MAX_SIZE = 1024;
+        this.locked = false;
+        this.batch_mode = false;
+        this.batch_state = null;
     }
+
+    push(item) {
+        if(this.locked) return;
+
+        if(this.batch_mode) {
+            this.batch_state = item;
+            return;
+        }
+
+        if (this.index !== this.data.length - 1) {
+            this.diverge();
+        }
+        this.data.push(item);
+        //remove from bottom of stack if we have more items than the max size allows
+        if (this.data.length >= this.MAX_SIZE) {
+            this.data.shift();
+        }
+        this.index = this.data.length - 1;
+    }
+
+    undo() {
+        if (this.index > 0) this.index -= 1;
+        return this.getState();
+    }
+
+    redo() {
+        if (this.index < this.data.length - 1) this.index += 1;
+        return this.getState();
+    }
+
+    getState() {
+        return this.data[this.index];
+    }
+
+    diverge() {
+        //remove all states after the current index
+        this.data.splice(this.index + 1);
+    }
+
+    lock() {
+        this.locked = true;
+    }
+
+    unlock() {
+        this.locked = false;
+    }
+
+    startBatch() {
+        this.batch_mode = true;
+        this.batch_state = null;
+    }
+
+    endBatch() {
+        this.batch_mode = false;
+        if (this.batch_state !== null) this.push(this.batch_state);
+    }
+
 }

--- a/src/components/Paper/Paper.css
+++ b/src/components/Paper/Paper.css
@@ -16,7 +16,3 @@
 .joint-paper {
     background-color: white;
 }
-
-#main-paper-proof-paper {
-    background-color: #ff92928f;
-}

--- a/src/components/Paper/Sheet/Sheet.js
+++ b/src/components/Paper/Sheet/Sheet.js
@@ -43,12 +43,9 @@ export default class Sheet {
     }
 
     exportAsJSON() {
-        console.log('exporting...');
         const cells = this.graph.getCells();
         const exported = cells.map(cell => Object.assign(cell.attributes, { sheet: null }));
-        console.log(exported);
         const json = JSON.stringify(exported, null, 2);
-        console.log(json);
         return json;
     }
 
@@ -304,7 +301,6 @@ export default class Sheet {
     
     findRoot(node) {
         while (true) {
-            console.log('FIND ROOT NODE', node)
             if (node.get("parent")) {
                 node = node.getParentCell();
             } else {
@@ -367,13 +363,11 @@ export default class Sheet {
             x: position.x - root.attributes.position.x,
             y: position.y - root.attributes.position.y
         }
-        console.log(offset);
         let current = [];
         let next = [root];
         while (next.length > 0) {
             current = next;
             next = [];
-            console.log(current);
             for (const node of current) {
                 next.push(...node.getEmbeddedCells());
                 //node.move({x: node.attributes.position.x + offset.x, y: node.attributes.position.y + offset.y})


### PR DESCRIPTION
* Adds Undo (Ctrl + Z) and Redo (Ctrl + Shift + Z)
* Each paper stores its own history (undo / redo is separate for create paper vs proof paper vs modal paper)
* history can be locked and unlocked to prevent certain changes from being added to the history (such as creation of temp cut)
* history can handle batch updates
  * call `history.startBatch()`
  * do multiple updates
  * call `history.endBatch()`
  * Now the multiple updates will be grouped into one entry in the history so undo / redo will affect all of them 

Also, the keyboard inputs have been fixed to hopefully no longer let a premise be any key on the keyboard 😞. Most key events are now in KeyDown instead of KeyUp