### PR TITLE
insertdblcut collisions fix

### DIFF
--- a/src/components/Paper/Sheet/Sheet.js
+++ b/src/components/Paper/Sheet/Sheet.js
@@ -44,9 +44,9 @@ export default class Sheet {
         return premise;
     }
 
-    addCut(config) {
-        const cut = (new Cut()).create(config, this);
-        this.handleCollisions(cut);
+    addCut(config, collisions=true) {
+        const cut = (new Cut()).create(config, this, collisions);
+        if (collisions) this.handleCollisions(cut);
 
         // Play snip sound
         let snip = new Audio(Snip); 

--- a/src/util/proof-util.js
+++ b/src/util/proof-util.js
@@ -56,7 +56,6 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
             }
         }, false));
     } 
-    console.log("NEW CUTS: ",new_cuts[0], new_cuts[1]);
     new_cuts[0].embed(new_cuts[1])
     sheet.colorByLevel(new_cuts[0])
     let selected_premise = sheet.paper.selected_premise;

--- a/src/util/proof-util.js
+++ b/src/util/proof-util.js
@@ -41,8 +41,9 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
         throw new Error('Bad arguments');
     }
     const multipliers = [0.8, 0.25];
+    let new_cuts = []
     for(let i = 0; i < multipliers.length; i++) { 
-        sheet.addCut({
+        new_cuts.push(sheet.addCut({
             position:  {
               x: position.x - (size.width * multipliers[i]/2),
               y: position.y - (size.height * multipliers[i]/2)
@@ -53,8 +54,18 @@ export const insertDoubleCut = function(sheet, model, mousePosition={}) {
                     height: size.height * (1 + multipliers[i])
                 }
             }
-        });
-    }  
+        }, false));
+    } 
+    console.log("NEW CUTS: ",new_cuts[0], new_cuts[1]);
+    new_cuts[0].embed(new_cuts[1])
+    sheet.colorByLevel(new_cuts[0])
+    let selected_premise = sheet.paper.selected_premise;
+    if (selected_premise && selected_premise.attributes.type === "dia.Element.Cut") {
+      selected_premise.embed(new_cuts[0]);
+      sheet.colorByLevel(selected_premise)
+      sheet.pack(selected_premise)
+    }
+    sheet.handleCollisions(new_cuts[0]) 
 }
 
 export const deleteDoubleCut = function(sheet, model) {


### PR DESCRIPTION
Fixed issue where inserting double cut would fail due to collisions between existing premises or cuts. Added boolean flag to disable collisions when adding a cut. Useful for when you know that collisions do not need to be calculated, or you are adding multiple things at once. 