### PR TITLE
add scaling options to scaleContentToFit() for HistoryItem

### DIFF
--- a/src/components/Paper/History/HistoryItem.jsx
+++ b/src/components/Paper/History/HistoryItem.jsx
@@ -24,7 +24,7 @@ export default class HistoryItem extends React.Component {
     componentDidUpdate(prevProps, prevState) {
         if(this.props.num === this.props.total -1 ){
             this.sheet.importCells(this.props.cells);
-            this.jpaper.scaleContentToFit();
+            this.jpaper.scaleContentToFit({fittingBBox: {x: 0, y: 0, width: 200, height: 200}, maxScaleX: 0.5, maxScaleY: 0.5});
         }
     }
 
@@ -40,7 +40,7 @@ export default class HistoryItem extends React.Component {
         });
 
         this.sheet.importCells(this.props.cells);
-        this.jpaper.scaleContentToFit();
+        this.jpaper.scaleContentToFit({fittingBBox: {x: 0, y: 0, width: 200, height: 200}, maxScaleX: 0.5, maxScaleY: 0.5} );
         this.jpaper.updateViews();
 
         this.jpaper.setInteractivity(false);


### PR DESCRIPTION
Fixes #69 
Before:
![image](https://user-images.githubusercontent.com/65693478/174854466-280a3e42-2108-4eaa-b604-0ee1beaf1feb.png)

After:
![image](https://user-images.githubusercontent.com/65693478/174854287-96a3b13b-8dc2-469c-a951-53dce266e87f.png)
